### PR TITLE
Randomness

### DIFF
--- a/Trace.Tests/RandomTests.cs
+++ b/Trace.Tests/RandomTests.cs
@@ -1,0 +1,26 @@
+/*===========================================================
+ |                     Raytracer Project
+ |             Released under EUPL-1.2 License
+ |                       See LICENSE
+ ===========================================================*/
+
+using Xunit;
+namespace Trace.Tests;
+
+public class RandomTests
+{
+    [Fact]
+    public void TestRandom()
+    {
+        var pcg = new Pcg();
+        Assert.True(pcg.State == 1753877967969059832);
+        Assert.True(pcg.Inc == 109);
+
+        foreach (var expected in new uint[]
+                 { 2707161783, 2068313097, 3122475824, 2211639955, 3215226955, 3421331566 })
+        {
+            var result = pcg.Random();
+            Assert.True(expected == result);
+        }
+    }
+}

--- a/Trace/Random.cs
+++ b/Trace/Random.cs
@@ -1,0 +1,45 @@
+namespace Trace;
+
+public class Pcg
+{
+    public ulong State;
+    public ulong Inc;
+
+    public Pcg(ulong initialState = 42, ulong initialSeq = 54)
+    {
+        State = 0;
+        Inc = (initialSeq << 1) | 1;
+        Random();
+        State += initialState;
+        Random();
+    }
+
+    /// <summary>
+    /// Returns a 32-bit unsigned pseudorandom number using PCG algorithm.
+    /// </summary>
+    /// <returns></returns>
+    public uint Random()
+    {
+        var oldState = State;
+
+        State = (oldState * 6364136223846793005 + Inc);
+
+        var xorShifted = (uint)(((oldState >> 18) ^ oldState) >> 27);
+
+        //this needs to be cast int AFTER the shift. Otherwise, it might shift badly.
+        var rot = oldState >> 59;
+
+        return (xorShifted >> (int)rot) | (xorShifted << ((-(int)rot) & 31));
+    }
+
+    /// <summary>
+    /// converting to float 2^32 (0xffffffff) prevents function loss
+    /// and actually gives a uniform number between 0 and 1 and not mostly 0 or 1.
+    /// </summary>
+    /// <returns></returns>
+    public float Random_float()
+    {
+        return Random()/ (float)0xffffffff;
+    }
+    
+}


### PR DESCRIPTION
## Implement PCG (Permuted Congruential Generator) RNG

### Summary

This PR introduces a fully functional implementation of the **PCG** random number generator for 32-bit unsigned integers, along with a helper method to generate normalized floating-point numbers in `[0, 1)`.

### Changes

- Added `Random()` method to generate 32-bit pseudorandom values using the PCG algorithm
- Added `Random_float()` method to generate `float` values in the range `[0, 1)`
- Ensured correct handling of bitwise operations and shift logic
- Fixed integer division and casting to avoid loss of precision
- (Optional) Added test assertions for deterministic output

